### PR TITLE
Binning and Mono8 Format

### DIFF
--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -132,6 +132,17 @@ class Capture
   }
 
   /**
+   * @brief set binning
+   * @return true if success
+   */
+  inline bool setBinning(int32_t bin_x, int32_t bin_y)
+  {
+      binning_x_ = bin_x;
+      binning_y_ = bin_y;
+      return true;
+  }
+
+  /**
    * @brief set CV_PROP_*
    * @return true if success
    */
@@ -188,6 +199,17 @@ class Capture
    * @brief camera info manager
    */
   camera_info_manager::CameraInfoManager info_manager_;
+
+
+  /**
+   * @brief Binning X
+   */
+  int32_t binning_x_;
+
+  /**
+   * @brief Binning Y
+   */
+  int32_t binning_y_;
 };
 
 }  // namespace cv_camera

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -18,7 +18,9 @@ Capture::Capture(ros::NodeHandle& node,
     topic_name_(topic_name),
     buffer_size_(buffer_size),
     frame_id_(frame_id),
-    info_manager_(node_, frame_id)
+    info_manager_(node_, frame_id),
+    binning_x_(0),
+    binning_y_(0)
 {
 }
 
@@ -95,7 +97,7 @@ bool Capture::capture()
   if (cap_.read(bridge_.image))
   {
     ros::Time now = ros::Time::now();
-    bridge_.encoding = enc::BGR8;
+    bridge_.encoding = bridge_.image.channels()==3?enc::BGR8:enc::MONO8;
     bridge_.header.stamp = now;
     bridge_.header.frame_id = frame_id_;
 
@@ -110,6 +112,8 @@ bool Capture::capture()
     }
     info_.header.stamp = now;
     info_.header.frame_id = frame_id_;
+    info_.binning_x = binning_x_;
+    info_.binning_y = binning_y_;
 
     return true;
   }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -26,6 +26,8 @@ void Driver::setup()
   std::string frame_id("camera");
   std::string file_path("");
 
+  int32_t binning_x = 0, binning_y = 0;
+
   private_node_.getParam("device_id", device_id);
   private_node_.getParam("frame_id", frame_id);
   private_node_.getParam("rate", hz);
@@ -58,6 +60,17 @@ void Driver::setup()
     if (!camera_->setHeight(image_height))
     {
       ROS_WARN("fail to set image_height");
+    }
+  }
+
+  bool bin_x_exists = private_node_.getParam("binning_x", binning_x);
+
+  if ( private_node_.getParam("binning_y", binning_y) ||
+       bin_x_exists )
+  {
+    if (!camera_->setBinning(binning_x, binning_y))
+    {
+      ROS_WARN("fail to set binning");
     }
   }
 


### PR DESCRIPTION
Takashi,

Can you please check my proposed changes? The changes are:

 1.- Set MONO8 format if number of channels is 1
 2.- Add binning option, specially to set the camera_info.binning_[xy] property, so that other modules (for example rectification) are able to perform the correct operations (for example, without the right binning parameter, image_proc rectification fails if binning or skipping is used).

Hernan
