### PR TITLE
Add device_path support

### DIFF
--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -50,6 +50,21 @@ class Capture
   void open(int32_t device_id);
 
   /**
+   * @brief Open capture device with device name.
+   *
+   * @param device_path path of the camera device
+   * @throw cv_camera::DeviceError device open failed
+   */
+  void open(std::string device_path);
+
+  /**
+   * @brief Load camera info from file.
+   *
+   * This loads the camera info from the file specified in the camera_info_url parameter.
+   */
+  void load_camera_info();
+
+  /**
    * @brief Open default camera device.
    *
    * This opens with device 0.

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -55,14 +55,14 @@ class Capture
    * @param device_path path of the camera device
    * @throw cv_camera::DeviceError device open failed
    */
-  void open(std::string device_path);
+  void open(const std::string& device_path);
 
   /**
    * @brief Load camera info from file.
    *
    * This loads the camera info from the file specified in the camera_info_url parameter.
    */
-  void load_camera_info();
+  void loadCameraInfo();
 
   /**
    * @brief Open default camera device.

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -22,7 +22,7 @@ Capture::Capture(ros::NodeHandle& node,
 {
 }
 
-void Capture::load_camera_info()
+void Capture::loadCameraInfo()
 {
   std::string url;
   if (node_.getParam("camera_info_url", url))
@@ -66,10 +66,10 @@ void Capture::open(int32_t device_id)
   }
   pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
 
-  load_camera_info();
+  loadCameraInfo();
 }
 
-void Capture::open(std::string device_path)
+void Capture::open(const std::string& device_path)
 {
   cap_.open(device_path, cv::CAP_V4L);
   if (!cap_.isOpened())
@@ -78,7 +78,7 @@ void Capture::open(std::string device_path)
   }
   pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
 
-  load_camera_info();
+  loadCameraInfo();
 }
 
 void Capture::open()

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -22,17 +22,8 @@ Capture::Capture(ros::NodeHandle& node,
 {
 }
 
-void Capture::open(int32_t device_id)
+void Capture::load_camera_info()
 {
-  cap_.open(device_id);
-  if (!cap_.isOpened())
-  {
-    std::stringstream stream;
-    stream << "device_id " << device_id << " cannot be opened";
-    throw DeviceError(stream.str());
-  }
-  pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
-
   std::string url;
   if (node_.getParam("camera_info_url", url))
   {
@@ -62,6 +53,32 @@ void Capture::open(int32_t device_id)
                        << std::endl);
     }
   }
+}
+
+void Capture::open(int32_t device_id)
+{
+  cap_.open(device_id);
+  if(!cap_.isOpened())
+  {
+    std::stringstream stream;
+    stream << "device_id" << device_id << " cannot be opened";
+    throw DeviceError(stream.str());
+  }
+  pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
+
+  load_camera_info();
+}
+
+void Capture::open(std::string device_path)
+{
+  cap_.open(device_path, cv::CAP_V4L);
+  if (!cap_.isOpened())
+  {
+    throw DeviceError("device_path " + device_path + " cannot be opened");
+  }
+  pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
+
+  load_camera_info();
 }
 
 void Capture::open()

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -42,8 +42,7 @@ void Driver::setup()
   if (private_node_.getParam("file", file_path) && file_path != "")
   {
     camera_->openFile(file_path);
-  } else if (private_node_.getParam("device_path", device_path) &&
-      device_path != "")
+  } else if (private_node_.getParam("device_path", device_path) && device_path != "")
   {
     camera_->open(device_path);
   }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -23,6 +23,7 @@ void Driver::setup()
 {
   double hz(DEFAULT_RATE);
   int32_t device_id(0);
+  std::string device_path("");
   std::string frame_id("camera");
   std::string file_path("");
 
@@ -37,10 +38,14 @@ void Driver::setup()
                             "image_raw",
                             PUBLISHER_BUFFER_SIZE,
                             frame_id));
-  if (private_node_.getParam("file", file_path) &&
-      file_path != "")
+
+  if (private_node_.getParam("file", file_path) && file_path != "")
   {
     camera_->openFile(file_path);
+  } else if (private_node_.getParam("device_path", device_path) &&
+      device_path != "")
+  {
+    camera_->open(device_path);
   }
   else
   {


### PR DESCRIPTION
I hope I'm doing this right, this is the first time I've submitted a pull request like this..

Some initial testing shows that the device_path parameter is working and opens the correct camera.  The device_path parameter takes precedence over the device_id parameter.

As discussed in #4 