### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/cv_camera_nodelet.cpp
+++ b/src/cv_camera_nodelet.cpp
@@ -77,4 +77,4 @@ class CvCameraNodelet : public nodelet::Nodelet
 }  // end namespace cv_camera
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(cv_camera, CvCameraNodelet, cv_camera::CvCameraNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(cv_camera::CvCameraNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions