### PR TITLE
Automatic rescaling camera info with rescale_camera_info parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If no calibration data is set, it has dummy values except for width and height.
 * ~image_height (int) try to set capture image height.
 * ~camera_info_url (string) url of camera info yaml.
 * ~file (string: default "") if not "" then use movie file instead of device.
+* ~rescale_camera_info (bool: default false) rescale camera calibration info automatically.
 
 supports CV_CAP_PROP_*, by below params.
 

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -154,6 +154,11 @@ class Capture
 
  private:
   /**
+   * @brief rescale camera calibration to another resolution
+   */
+  void rescaleCameraInfo(int width, int height);
+
+  /**
    * @brief node handle for advertise.
    */
   ros::NodeHandle node_;
@@ -203,6 +208,11 @@ class Capture
    * @brief camera info manager
    */
   camera_info_manager::CameraInfoManager info_manager_;
+
+  /**
+   * @brief rescale_camera_info param value
+   */
+  bool rescale_camera_info_;
 };
 
 }  // namespace cv_camera


### PR DESCRIPTION
This PR resolves #10, adding `~rescale_camera_info` parameter.

While coding I met 3 issues, so I'm not sure the approach I used is correct:

* The `info_manager_.getCameraInfo()` is called on every camera frame, and (using `~set_camera_info` service) the camera info can change at any moment. So if there is resolution mismatch, the calibration is recalculated all the time.
* If the user calls `~set_camera_info` twice, the warning message would not appear second time, as I used `ROS_WARN_ONCE`.
* `SetCameraInfo` documentation [says](http://docs.ros.org/jade/api/sensor_msgs/html/srv/SetCameraInfo.html):
> The width and height in the camera_info field should match what the is currently outputting on its camera_info topic.

So I don't know, if the camera node intended to rescale camera info parameters by the ROS authors' idea.