### PR TITLE
Fix rescaling coefficient calculation

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -57,8 +57,8 @@ void Capture::loadCameraInfo()
 
 void Capture::rescaleCameraInfo(int width, int height)
 {
-  double width_coeff = width / info_.width;
-  double height_coeff = height / info_.height;
+  double width_coeff = static_cast<double>(width) / info_.width;
+  double height_coeff = static_cast<double>(height) / info_.height;
   info_.width = width;
   info_.height = height;
 


### PR DESCRIPTION
After a real-life testing the feature of automatic camera calibration rescaling, found a bug.
The division was modulo as the old width/height and new width/height were integer.