### PR TITLE
Allow specifying camera name for camera_info_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If no calibration data is set, it has dummy values except for width and height.
 * `~file` (*string*, default: "") – if not "" then use movie file instead of device.
 * `~capture_delay` (*double*, default: 0) – estimated duration of capturing and receiving the image.
 * `~rescale_camera_info` (*bool*, default: false) – rescale camera calibration info automatically.
+* `~camera_name` (*bool*, default: same as `frame_id`) – camera name for `camera_info_manager`.
 
 Supports CV_CAP_PROP_*, by below params.
 

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -34,11 +34,13 @@ public:
    * @param topic_name name of topic to publish (this may be image_raw).
    * @param buffer_size size of publisher buffer.
    * @param frame_id frame_id of publishing messages.
+   * @param camera_name camera name for camera_info_manager.
    */
   Capture(ros::NodeHandle &node,
           const std::string &topic_name,
           int32_t buffer_size,
-          const std::string &frame_id);
+          const std::string &frame_id,
+          const std::string &camera_name);
 
   /**
    * @brief Open capture device with device ID.

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -10,13 +10,14 @@ namespace cv_camera
 namespace enc = sensor_msgs::image_encodings;
 
 Capture::Capture(ros::NodeHandle &node, const std::string &topic_name,
-                 int32_t buffer_size, const std::string &frame_id)
+                 int32_t buffer_size, const std::string &frame_id,
+                 const std::string& camera_name)
     : node_(node),
       it_(node_),
       topic_name_(topic_name),
       buffer_size_(buffer_size),
       frame_id_(frame_id),
-      info_manager_(node_, frame_id),
+      info_manager_(node_, camera_name),
       capture_delay_(ros::Duration(node_.param("capture_delay", 0.0)))
 {
 }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -25,10 +25,15 @@ void Driver::setup()
   std::string device_path("");
   std::string frame_id("camera");
   std::string file_path("");
+  std::string camera_name("");
 
   private_node_.getParam("device_id", device_id);
   private_node_.getParam("frame_id", frame_id);
   private_node_.getParam("rate", hz);
+  if (!private_node_.getParam("camera_name", camera_name))
+  {
+    camera_name = frame_id;
+  }
 
   int32_t image_width(640);
   int32_t image_height(480);
@@ -36,7 +41,8 @@ void Driver::setup()
   camera_.reset(new Capture(camera_node_,
                             "image_raw",
                             PUBLISHER_BUFFER_SIZE,
-                            frame_id));
+                            frame_id,
+                            camera_name));
 
   if (private_node_.getParam("file", file_path) && file_path != "")
   {


### PR DESCRIPTION
As of 0.4.0, the `camera_name` that is passed to `camera_info_manager` matches the `frame_id` of the published messages. This is not always the desired behavior: the frames may have names that match the camera's role (`main_camera_optical`, `front_camera_optical`), while the actual camera name may differ (`raspicam`, `logitech_camera`). At the very least this will produce a warning by `camera_info_manager` about the camera name not matching the frame_id.

Specifying the `camera_name` for `camera_info_manager` also allows the latter to load the camera calibration info from the default location (`~/.ros/camera_info/${camera_name}.yaml`).