### PR TITLE
OpenCV 4 compatibility

### DIFF
--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -136,7 +136,7 @@ public:
    */
   inline bool setWidth(int32_t width)
   {
-    return cap_.set(CV_CAP_PROP_FRAME_WIDTH, width);
+    return cap_.set(cv::CAP_PROP_FRAME_WIDTH, width);
   }
 
   /**
@@ -145,7 +145,7 @@ public:
    */
   inline bool setHeight(int32_t height)
   {
-    return cap_.set(CV_CAP_PROP_FRAME_HEIGHT, height);
+    return cap_.set(cv::CAP_PROP_FRAME_HEIGHT, height);
   }
 
   /**

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -71,34 +71,28 @@ void Driver::setup()
     }
   }
 
-  camera_->setPropertyFromParam(CV_CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
-  camera_->setPropertyFromParam(CV_CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
-  camera_->setPropertyFromParam(CV_CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-  camera_->setPropertyFromParam(CV_CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-  camera_->setPropertyFromParam(CV_CAP_PROP_FPS, "cv_cap_prop_fps");
-  camera_->setPropertyFromParam(CV_CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
-  camera_->setPropertyFromParam(CV_CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
-  camera_->setPropertyFromParam(CV_CAP_PROP_FORMAT, "cv_cap_prop_format");
-  camera_->setPropertyFromParam(CV_CAP_PROP_MODE, "cv_cap_prop_mode");
-  camera_->setPropertyFromParam(CV_CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-  camera_->setPropertyFromParam(CV_CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-  camera_->setPropertyFromParam(CV_CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-  camera_->setPropertyFromParam(CV_CAP_PROP_HUE, "cv_cap_prop_hue");
-  camera_->setPropertyFromParam(CV_CAP_PROP_GAIN, "cv_cap_prop_gain");
-  camera_->setPropertyFromParam(CV_CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-  camera_->setPropertyFromParam(CV_CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
+  camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
+  camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
+  camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
+  camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+  camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+  camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+  camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+  camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+  camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+  camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
 
-  camera_->setPropertyFromParam(CV_CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
-  camera_->setPropertyFromParam(CV_CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
-#ifdef CV_CAP_PROP_WHITE_BALANCE_U
-  camera_->setPropertyFromParam(CV_CAP_PROP_WHITE_BALANCE_U, "cv_cap_prop_white_balance_u");
-#endif // CV_CAP_PROP_WHITE_BALANCE_U
-#ifdef CV_CAP_PROP_WHITE_BALANCE_V
-  camera_->setPropertyFromParam(CV_CAP_PROP_WHITE_BALANCE_V, "cv_cap_prop_white_balance_v");
-#endif // CV_CAP_PROP_WHITE_BALANCE_V
-#ifdef CV_CAP_PROP_BUFFERSIZE
-  camera_->setPropertyFromParam(CV_CAP_PROP_BUFFERSIZE, "cv_cap_prop_buffersize");
-#endif // CV_CAP_PROP_BUFFERSIZE
+  camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
+  camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
+  camera_->setPropertyFromParam(cv::CAP_PROP_WHITE_BALANCE_BLUE_U, "cv_cap_prop_white_balance_u");
+  camera_->setPropertyFromParam(cv::CAP_PROP_WHITE_BALANCE_RED_V, "cv_cap_prop_white_balance_v");
+  camera_->setPropertyFromParam(cv::CAP_PROP_BUFFERSIZE, "cv_cap_prop_buffersize");
 
   rate_.reset(new ros::Rate(hz));
 }


### PR DESCRIPTION
ROS Noetic targets platforms with [OpenCV 4+](https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025). Unfortunately, C-style definitions [have been removed](https://opencv.org/opencv-4-0/) in recent OpenCV releases.

This pull request replaces old, OpenCV 2.x-style defines with OpenCV 3.x enums, allowing the node to be built for Noetic.

The changes should work for Kinetic (OpenCV 3.3.1) and Melodic (OpenCV 3.2+) as well. They may not work for older ROS releases.